### PR TITLE
Add Slideout option to disable touch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Create a new instance of `Slideout`.
 - `[options.fx]` (String) - The CSS effect to use when animating the opening and closing of the slideout. Default: `ease`.
 - `[options.padding]` (Number) - Default: `256`.
 - `[options.tolerance]` (Number) - Default: `70`.
+- `[options.touch]` (Boolean) - Set this option to false to disable Slideout touch events. Default: `true`.
 
 ```js
 var slideout = new Slideout({

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function Slideout(options) {
   this._moved = false;
   this._opened = false;
   this._preventOpen = false;
+  this._touch = options.touch == undefined ? true : options.touch && true;
 
   // Sets panel
   this.panel = options.panel;
@@ -63,7 +64,9 @@ function Slideout(options) {
   this._padding = parseInt(options.padding, 10) || 256;
 
   // Init touch events
-  this._initTouchEvents();
+  if(this._touch) {
+    this._initTouchEvents();
+  }
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,8 @@ describe('Slideout', function () {
       '_fx',
       '_duration',
       '_tolerance',
-      '_padding'
+      '_padding',
+      '_touch'
     ];
     var i = 0;
     var len = properties.length;


### PR DESCRIPTION
I added an option to disable ```Slideout``` touch events. 
**Why ?** I have created an app that has google maps on the main panel and the ```Slideout``` touch events overlaps google maps touch events. 
Setting this option, let the user navigate google maps without having to deal with ```Slideout``` menu popping in the panel. 